### PR TITLE
Specify threads for samtools in extract_reads.nf and bam_to_fastq.nf

### DIFF
--- a/modules/local/bam_to_fastq.nf
+++ b/modules/local/bam_to_fastq.nf
@@ -7,6 +7,6 @@ process BAM_TO_FASTQ {
   path "*.fastq", emit: realigned_ch
 
 	"""
-  samtools fastq -1 ${bamFile.baseName}.r1.fastq -2 ${bamFile.baseName}.r2.fastq -0 /dev/null -s /dev/null -n ${bamFile}
+  samtools fastq --threads $task.cpus -1 ${bamFile.baseName}.r1.fastq -2 ${bamFile.baseName}.r2.fastq -0 /dev/null -s /dev/null -n ${bamFile}
 	"""
 }

--- a/modules/local/extract_reads.nf
+++ b/modules/local/extract_reads.nf
@@ -7,6 +7,6 @@ process EXTRACT_READS {
   path "*.extracted.bam", emit: extracted_bams_ch
 
   """
-  samtools view --threads $task.cpus -hb -L ${regionFile} ${bamFile} | samtools sort $task.cpus -n -o ${bamFile.baseName}.extracted.bam -
+  samtools view --threads $task.cpus -hb -L ${regionFile} ${bamFile} | samtools sort --threads $task.cpus -n -o ${bamFile.baseName}.extracted.bam -
 	"""
 }

--- a/modules/local/extract_reads.nf
+++ b/modules/local/extract_reads.nf
@@ -7,6 +7,6 @@ process EXTRACT_READS {
   path "*.extracted.bam", emit: extracted_bams_ch
 
   """
-  samtools view -hb -L ${regionFile} ${bamFile} | samtools sort -n -o ${bamFile.baseName}.extracted.bam -
+  samtools view --threads $task.cpus -hb -L ${regionFile} ${bamFile} | samtools sort $task.cpus -n -o ${bamFile.baseName}.extracted.bam -
 	"""
 }


### PR DESCRIPTION
Hi Sebastian,

This pull request allows `samtools` to use multiple threads when extracting the reads and creating the fastq.